### PR TITLE
fix(generator): annotate TImpl with [DynamicallyAccessedMembers] on Add{Service}Resilience (closes #10)

### DIFF
--- a/samples/ZeroAlloc.Resilience.AotSmoke/ZeroAlloc.Resilience.AotSmoke.csproj
+++ b/samples/ZeroAlloc.Resilience.AotSmoke/ZeroAlloc.Resilience.AotSmoke.csproj
@@ -7,10 +7,7 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <OptimizationPreference>Size</OptimizationPreference>
 
-    <!-- IL2091 temporarily suppressed — generator's DI extension is missing
-         [DynamicallyAccessedMembers(PublicConstructors)] on TImpl (tracked as #10) -->
-    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2067;IL2075;IL3050;IL3051</WarningsAsErrors>
-    <NoWarn>$(NoWarn);IL2091</NoWarn>
+    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2067;IL2075;IL2091;IL3050;IL3051</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ZeroAlloc.Resilience.Generator/ResilienceWriter.cs
+++ b/src/ZeroAlloc.Resilience.Generator/ResilienceWriter.cs
@@ -270,7 +270,11 @@ internal static class ResilienceWriter
 
         sb.AppendLine("public static partial class ResilienceServiceCollectionExtensions");
         sb.AppendLine("{");
-        sb.AppendLine($"    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection Add{model.InterfaceName.TrimStart('I')}Resilience<TImpl>(");
+        sb.AppendLine($"    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection Add{model.InterfaceName.TrimStart('I')}Resilience<");
+        // IL2091: TImpl flows into AddTransient<T> which requires PublicConstructors.
+        sb.AppendLine("        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(");
+        sb.AppendLine("            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]");
+        sb.AppendLine("        TImpl>(");
         sb.AppendLine($"        this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)");
         sb.AppendLine($"        where TImpl : class, {model.InterfaceFqn}");
         sb.AppendLine("    {");

--- a/tests/ZeroAlloc.Resilience.Generator.Tests/Snapshots/SnapshotTests.AllPolicies_ClassLevel_GeneratesProxy#T_IExternalService.Resilience.g.verified.cs
+++ b/tests/ZeroAlloc.Resilience.Generator.Tests/Snapshots/SnapshotTests.AllPolicies_ClassLevel_GeneratesProxy#T_IExternalService.Resilience.g.verified.cs
@@ -106,7 +106,10 @@ internal sealed class IExternalServiceResilienceProxy : global::T.IExternalServi
 
 public static partial class ResilienceServiceCollectionExtensions
 {
-    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddExternalServiceResilience<TImpl>(
+    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddExternalServiceResilience<
+        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TImpl>(
         this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
         where TImpl : class, global::T.IExternalService
     {

--- a/tests/ZeroAlloc.Resilience.Generator.Tests/Snapshots/SnapshotTests.CircuitBreaker_WithFallback_GeneratesProxy#T_IMyService.Resilience.g.verified.cs
+++ b/tests/ZeroAlloc.Resilience.Generator.Tests/Snapshots/SnapshotTests.CircuitBreaker_WithFallback_GeneratesProxy#T_IMyService.Resilience.g.verified.cs
@@ -64,7 +64,10 @@ internal sealed class IMyServiceResilienceProxy : global::T.IMyService
 
 public static partial class ResilienceServiceCollectionExtensions
 {
-    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceResilience<TImpl>(
+    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceResilience<
+        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TImpl>(
         this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
         where TImpl : class, global::T.IMyService
     {

--- a/tests/ZeroAlloc.Resilience.Generator.Tests/Snapshots/SnapshotTests.MethodLevel_Override_GeneratesProxy#T_IMyService.Resilience.g.verified.cs
+++ b/tests/ZeroAlloc.Resilience.Generator.Tests/Snapshots/SnapshotTests.MethodLevel_Override_GeneratesProxy#T_IMyService.Resilience.g.verified.cs
@@ -78,7 +78,10 @@ internal sealed class IMyServiceResilienceProxy : global::T.IMyService
 
 public static partial class ResilienceServiceCollectionExtensions
 {
-    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceResilience<TImpl>(
+    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceResilience<
+        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TImpl>(
         this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
         where TImpl : class, global::T.IMyService
     {

--- a/tests/ZeroAlloc.Resilience.Generator.Tests/Snapshots/SnapshotTests.Retry_Only_GeneratesProxy#T_IMyService.Resilience.g.verified.cs
+++ b/tests/ZeroAlloc.Resilience.Generator.Tests/Snapshots/SnapshotTests.Retry_Only_GeneratesProxy#T_IMyService.Resilience.g.verified.cs
@@ -46,7 +46,10 @@ internal sealed class IMyServiceResilienceProxy : global::T.IMyService
 
 public static partial class ResilienceServiceCollectionExtensions
 {
-    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceResilience<TImpl>(
+    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceResilience<
+        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TImpl>(
         this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
         where TImpl : class, global::T.IMyService
     {


### PR DESCRIPTION
Closes #10. Same fix pattern as ZeroAlloc.Cache#8.

Generator now emits `[DynamicallyAccessedMembers(PublicConstructors)]` on `TImpl` — IL2091 cleared.