### PR TITLE
fix: stop publishing broken stand-alone generator nupkg

### DIFF
--- a/src/ZeroAlloc.Resilience.Generator/ZeroAlloc.Resilience.Generator.csproj
+++ b/src/ZeroAlloc.Resilience.Generator/ZeroAlloc.Resilience.Generator.csproj
@@ -10,6 +10,13 @@
     <Version>0.0.0-local</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <NoWarn>$(NoWarn);RS2008;MA0051</NoWarn>
+    <!--
+      The generator is bundled into ZeroAlloc.Resilience's NuGet package via the
+      IncludeGeneratorInPackage target in the main library's csproj. Publishing a
+      separate ZeroAlloc.Resilience.Generator package would just produce a broken
+      stand-alone nupkg (DLL under lib/, not analyzers/), so suppress packing here.
+    -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" PrivateAssets="all" />


### PR DESCRIPTION
## Summary
The generator is already bundled into `ZeroAlloc.Resilience`'s NuGet package via the `IncludeGeneratorInPackage` target in the main library's csproj. The generator project's default `IsPackable=true` was causing `dotnet pack` to also produce a stand-alone `ZeroAlloc.Resilience.Generator` nupkg with the DLL under `lib/netstandard2.0/` instead of `analyzers/dotnet/cs/` — Roslyn can't load it from there.

Setting `IsPackable=false` makes the bundled-only intent explicit and prevents the broken stand-alone package from leaking out to nuget.org. Consumers continue to get the generator via `ZeroAlloc.Resilience` (one package, no change required).

Related: ZeroAlloc-Net/ZeroAlloc.Rest#67 — the same root cause across the ecosystem.

## Test plan
- [ ] CI green
- [ ] `dotnet pack` only produces `ZeroAlloc.Resilience.nupkg` (no `.Generator.nupkg`)
- [ ] The bundled generator DLL still appears at `analyzers/dotnet/cs/` inside the main package

🤖 Generated with [Claude Code](https://claude.com/claude-code)