### PR TITLE
feat: lock public API surface (PublicApiAnalyzers + api-compat gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,9 @@ jobs:
 
       - name: Run AOT binary
         run: ./aot-out/ZeroAlloc.Resilience.AotSmoke
+
+  api-compat:
+    uses: ZeroAlloc-Net/.github/.github/workflows/api-compat.yml@main
+    with:
+      package-id: ZeroAlloc.Resilience
+      csproj-path: src/ZeroAlloc.Resilience/ZeroAlloc.Resilience.csproj

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Explicitly elevate public-API analyzer diagnostics so the surface
+         stays locked even if TreatWarningsAsErrors is ever scoped down. -->
+    <WarningsAsErrors>$(WarningsAsErrors);RS0016;RS0017</WarningsAsErrors>
     <!-- Pre-existing code has multiple types per file (MA0048) and intentional custom exception (RCS1194) -->
     <NoWarn>$(NoWarn);MA0048;RCS1194</NoWarn>
 

--- a/src/ZeroAlloc.Resilience/PublicAPI.Shipped.txt
+++ b/src/ZeroAlloc.Resilience/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ZeroAlloc.Resilience/PublicAPI.Unshipped.txt
+++ b/src/ZeroAlloc.Resilience/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ZeroAlloc.Resilience/PublicAPI.Unshipped.txt
+++ b/src/ZeroAlloc.Resilience/PublicAPI.Unshipped.txt
@@ -1,1 +1,96 @@
 #nullable enable
+ZeroAlloc.Resilience.CircuitBreakerAttribute
+ZeroAlloc.Resilience.CircuitBreakerAttribute.CircuitBreakerAttribute() -> void
+ZeroAlloc.Resilience.CircuitBreakerAttribute.Fallback.get -> string?
+ZeroAlloc.Resilience.CircuitBreakerAttribute.Fallback.init -> void
+ZeroAlloc.Resilience.CircuitBreakerAttribute.HalfOpenProbes.get -> int
+ZeroAlloc.Resilience.CircuitBreakerAttribute.HalfOpenProbes.init -> void
+ZeroAlloc.Resilience.CircuitBreakerAttribute.MaxFailures.get -> int
+ZeroAlloc.Resilience.CircuitBreakerAttribute.MaxFailures.init -> void
+ZeroAlloc.Resilience.CircuitBreakerAttribute.ResetMs.get -> int
+ZeroAlloc.Resilience.CircuitBreakerAttribute.ResetMs.init -> void
+ZeroAlloc.Resilience.CircuitBreakerFsm
+ZeroAlloc.Resilience.CircuitBreakerFsm.CircuitBreakerFsm() -> void
+ZeroAlloc.Resilience.CircuitBreakerFsm.Current.get -> ZeroAlloc.Resilience.CircuitBreakerState
+ZeroAlloc.Resilience.CircuitBreakerFsm.TryFire(ZeroAlloc.Resilience.CircuitBreakerTrigger trigger) -> bool
+ZeroAlloc.Resilience.CircuitBreakerPolicy
+ZeroAlloc.Resilience.CircuitBreakerPolicy.CanExecute() -> bool
+ZeroAlloc.Resilience.CircuitBreakerPolicy.CircuitBreakerPolicy(int maxFailures, int resetMs, int halfOpenProbes) -> void
+ZeroAlloc.Resilience.CircuitBreakerPolicy.Dispose() -> void
+ZeroAlloc.Resilience.CircuitBreakerPolicy.OnFailure(System.Exception! _) -> void
+ZeroAlloc.Resilience.CircuitBreakerPolicy.OnSuccess() -> void
+ZeroAlloc.Resilience.CircuitBreakerPolicy.State.get -> ZeroAlloc.Resilience.CircuitBreakerState
+ZeroAlloc.Resilience.CircuitBreakerState
+ZeroAlloc.Resilience.CircuitBreakerState.Closed = 0 -> ZeroAlloc.Resilience.CircuitBreakerState
+ZeroAlloc.Resilience.CircuitBreakerState.HalfOpen = 2 -> ZeroAlloc.Resilience.CircuitBreakerState
+ZeroAlloc.Resilience.CircuitBreakerState.Open = 1 -> ZeroAlloc.Resilience.CircuitBreakerState
+ZeroAlloc.Resilience.CircuitBreakerTrigger
+ZeroAlloc.Resilience.CircuitBreakerTrigger.FailInHalfOpen = 3 -> ZeroAlloc.Resilience.CircuitBreakerTrigger
+ZeroAlloc.Resilience.CircuitBreakerTrigger.Probe = 1 -> ZeroAlloc.Resilience.CircuitBreakerTrigger
+ZeroAlloc.Resilience.CircuitBreakerTrigger.Success = 2 -> ZeroAlloc.Resilience.CircuitBreakerTrigger
+ZeroAlloc.Resilience.CircuitBreakerTrigger.Trip = 0 -> ZeroAlloc.Resilience.CircuitBreakerTrigger
+ZeroAlloc.Resilience.RateLimitAttribute
+ZeroAlloc.Resilience.RateLimitAttribute.BurstSize.get -> int
+ZeroAlloc.Resilience.RateLimitAttribute.BurstSize.init -> void
+ZeroAlloc.Resilience.RateLimitAttribute.MaxPerSecond.get -> int
+ZeroAlloc.Resilience.RateLimitAttribute.MaxPerSecond.init -> void
+ZeroAlloc.Resilience.RateLimitAttribute.RateLimitAttribute() -> void
+ZeroAlloc.Resilience.RateLimitAttribute.Scope.get -> ZeroAlloc.Resilience.RateLimitScope
+ZeroAlloc.Resilience.RateLimitAttribute.Scope.init -> void
+ZeroAlloc.Resilience.RateLimitScope
+ZeroAlloc.Resilience.RateLimitScope.Instance = 1 -> ZeroAlloc.Resilience.RateLimitScope
+ZeroAlloc.Resilience.RateLimitScope.Shared = 0 -> ZeroAlloc.Resilience.RateLimitScope
+ZeroAlloc.Resilience.RateLimiter
+ZeroAlloc.Resilience.RateLimiter.RateLimiter(int maxPerSecond, int burstSize, ZeroAlloc.Resilience.RateLimitScope scope) -> void
+ZeroAlloc.Resilience.RateLimiter.Scope.get -> ZeroAlloc.Resilience.RateLimitScope
+ZeroAlloc.Resilience.RateLimiter.TryAcquire() -> bool
+ZeroAlloc.Resilience.ResilienceError
+ZeroAlloc.Resilience.ResilienceError.Deconstruct(out string! PolicyType, out string! Reason, out System.Exception? InnerException) -> void
+ZeroAlloc.Resilience.ResilienceError.Equals(ZeroAlloc.Resilience.ResilienceError other) -> bool
+ZeroAlloc.Resilience.ResilienceError.InnerException.get -> System.Exception?
+ZeroAlloc.Resilience.ResilienceError.InnerException.init -> void
+ZeroAlloc.Resilience.ResilienceError.PolicyType.get -> string!
+ZeroAlloc.Resilience.ResilienceError.PolicyType.init -> void
+ZeroAlloc.Resilience.ResilienceError.Reason.get -> string!
+ZeroAlloc.Resilience.ResilienceError.Reason.init -> void
+ZeroAlloc.Resilience.ResilienceError.ResilienceError() -> void
+ZeroAlloc.Resilience.ResilienceError.ResilienceError(string! PolicyType, string! Reason, System.Exception? InnerException = null) -> void
+ZeroAlloc.Resilience.ResilienceException
+ZeroAlloc.Resilience.ResilienceException.Policy.get -> ZeroAlloc.Resilience.ResiliencePolicy
+ZeroAlloc.Resilience.ResilienceException.ResilienceException(ZeroAlloc.Resilience.ResiliencePolicy policy, string! message, System.Exception? inner = null) -> void
+ZeroAlloc.Resilience.ResiliencePolicy
+ZeroAlloc.Resilience.ResiliencePolicy.CircuitBreaker = 3 -> ZeroAlloc.Resilience.ResiliencePolicy
+ZeroAlloc.Resilience.ResiliencePolicy.RateLimit = 2 -> ZeroAlloc.Resilience.ResiliencePolicy
+ZeroAlloc.Resilience.ResiliencePolicy.Retry = 0 -> ZeroAlloc.Resilience.ResiliencePolicy
+ZeroAlloc.Resilience.ResiliencePolicy.Timeout = 1 -> ZeroAlloc.Resilience.ResiliencePolicy
+ZeroAlloc.Resilience.RetryAttribute
+ZeroAlloc.Resilience.RetryAttribute.BackoffMs.get -> int
+ZeroAlloc.Resilience.RetryAttribute.BackoffMs.init -> void
+ZeroAlloc.Resilience.RetryAttribute.Jitter.get -> bool
+ZeroAlloc.Resilience.RetryAttribute.Jitter.init -> void
+ZeroAlloc.Resilience.RetryAttribute.MaxAttempts.get -> int
+ZeroAlloc.Resilience.RetryAttribute.MaxAttempts.init -> void
+ZeroAlloc.Resilience.RetryAttribute.NonThrowing.get -> bool
+ZeroAlloc.Resilience.RetryAttribute.NonThrowing.init -> void
+ZeroAlloc.Resilience.RetryAttribute.PerAttemptTimeoutMs.get -> int
+ZeroAlloc.Resilience.RetryAttribute.PerAttemptTimeoutMs.init -> void
+ZeroAlloc.Resilience.RetryAttribute.RetryAttribute() -> void
+ZeroAlloc.Resilience.RetryPolicy
+ZeroAlloc.Resilience.RetryPolicy.BackoffMs.get -> int
+ZeroAlloc.Resilience.RetryPolicy.GetBackoffMs(int attempt) -> int
+ZeroAlloc.Resilience.RetryPolicy.Jitter.get -> bool
+ZeroAlloc.Resilience.RetryPolicy.MaxAttempts.get -> int
+ZeroAlloc.Resilience.RetryPolicy.PerAttemptTimeoutMs.get -> int
+ZeroAlloc.Resilience.RetryPolicy.RetryPolicy(int maxAttempts, int backoffMs, bool jitter, int perAttemptTimeoutMs) -> void
+ZeroAlloc.Resilience.TimeoutAttribute
+ZeroAlloc.Resilience.TimeoutAttribute.Ms.get -> int
+ZeroAlloc.Resilience.TimeoutAttribute.Ms.init -> void
+ZeroAlloc.Resilience.TimeoutAttribute.TimeoutAttribute() -> void
+ZeroAlloc.Resilience.TimeoutPolicy
+ZeroAlloc.Resilience.TimeoutPolicy.TimeoutPolicy(int totalMs) -> void
+ZeroAlloc.Resilience.TimeoutPolicy.TotalMs.get -> int
+override ZeroAlloc.Resilience.ResilienceError.GetHashCode() -> int
+override ZeroAlloc.Resilience.ResilienceError.ToString() -> string!
+static ZeroAlloc.Resilience.ResilienceError.operator !=(ZeroAlloc.Resilience.ResilienceError left, ZeroAlloc.Resilience.ResilienceError right) -> bool
+static ZeroAlloc.Resilience.ResilienceError.operator ==(ZeroAlloc.Resilience.ResilienceError left, ZeroAlloc.Resilience.ResilienceError right) -> bool
+~override ZeroAlloc.Resilience.ResilienceError.Equals(object obj) -> bool

--- a/src/ZeroAlloc.Resilience/ZeroAlloc.Resilience.csproj
+++ b/src/ZeroAlloc.Resilience/ZeroAlloc.Resilience.csproj
@@ -15,10 +15,19 @@
     <PackageReference Include="ZeroAlloc.Pipeline" Version="0.1.6" />
     <PackageReference Include="ZeroAlloc.Collections" Version="0.1.5" />
     <PackageReference Include="ZeroAlloc.Results" Version="0.1.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <ProjectReference Include="..\ZeroAlloc.Resilience.Generator\ZeroAlloc.Resilience.Generator.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false"
                       PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
   <Target Name="IncludeGeneratorInPackage" BeforeTargets="_GetPackageFiles">
     <ItemGroup>


### PR DESCRIPTION
## Summary

- Adds `Microsoft.CodeAnalysis.PublicApiAnalyzers` (4.14.0) to the runtime project (`src/ZeroAlloc.Resilience`) with `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` tracking files. Generator project intentionally excluded.
- Captures the current 1.1.x public surface (95 symbols) into `PublicAPI.Unshipped.txt` so RS0016 (undeclared) / RS0017 (removed) now break the build on any unintended surface change.
- Promotes `RS0016` / `RS0017` to errors via `Directory.Build.props` (in addition to the repo's existing `TreatWarningsAsErrors=true`, so the gate survives any future scoping of TWAE).
- Wires Phase B fan-out: a new `api-compat` job in `.github/workflows/ci.yml` consuming the org reusable workflow at `ZeroAlloc-Net/.github/.github/workflows/api-compat.yml@main`, comparing each PR's public surface against the package on nuget.org.

Sibling PRs in the public-API gating fan-out:
- ZeroAlloc-Net/ZeroAlloc.Authorization#5
- ZeroAlloc-Net/ZeroAlloc.AsyncEvents#47
- ZeroAlloc-Net/ZeroAlloc.Notify#43
- ZeroAlloc-Net/ZeroAlloc.Telemetry#19
- ZeroAlloc-Net/ZeroAlloc.ValueObjects#38
- ZeroAlloc-Net/ZeroAlloc.Outbox#44
- ZeroAlloc-Net/ZeroAlloc.Scheduling#44

## Test plan

- [x] `dotnet build src/ZeroAlloc.Resilience/ZeroAlloc.Resilience.csproj -c Release` clean (0 warnings, 0 errors across net8.0/net9.0/net10.0) after baselining
- [x] `dotnet build ZeroAlloc.Resilience.slnx -c Release` clean in an isolated worktree (build/test/AotSmoke/Benchmarks/Generator/Generator.Tests)
- [x] `dotnet test -c Release` passes (34/34 across runtime + generator suites)
- [x] Local rebuild after baselining yields 0 RS0016 / 0 RS0017
- [ ] CI `api-compat` job succeeds on this PR (validates baseline matches the nuget.org 1.1.x surface)
- [ ] CI `build` + `aot-smoke` jobs remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)