### PR TITLE
fix(release-please): drop pre-major flags (package is post-1.0)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,8 +2,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

Removes `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` from `release-please-config.json`. Both options only affect 0.x versions; ZeroAlloc.Resilience is at **1.2.0**, so they are dead config.

Leaving them in place is a silent SemVer hazard: if the package ever regresses to 0.x (or someone copies this config into a pre-1.0 package), these flags would suppress proper minor/major bumps for `feat!` / breaking changes. Stripping them now makes the config self-documenting and matches family-wide convention for post-1.0 packages.

## Why

- Package version is 1.2.0 -> options are no-ops today.
- Keeping pre-major flags on a post-1.0 package is a known footgun (release-please docs).
- Aligns with the family-wide sweep across ZeroAlloc post-1.0 packages.

## Behavior

- No behavioral change at 1.x.
- Post-1.0 SemVer semantics apply unchanged: `feat` -> minor, `fix` -> patch, breaking -> major.

## Test plan

- [ ] CI passes on this branch.
- [ ] Next release-please run produces the expected version bump for the next conventional commit.
- [ ] Do **not** merge until the family-wide sweep is reviewed together.