### PR TITLE
chore(benchmarks): pin shared-state assumption + tracking link from review

### DIFF
--- a/benchmarks/ZeroAlloc.Resilience.Benchmarks/PollyComparisonBenchmark.cs
+++ b/benchmarks/ZeroAlloc.Resilience.Benchmarks/PollyComparisonBenchmark.cs
@@ -48,6 +48,8 @@ public class PollyComparisonBenchmark
 
         _zaRetry = new IRetryServiceResilienceProxy(_inner, retry);
         _zaCb = new ICircuitServiceResilienceProxy(_inner, cb);
+        // RetryWith2FailuresImpl carries an Interlocked counter — the two pipelines
+        // MUST get separate instances; do not "dedupe" this allocation.
         _zaRetryFailTwice = new IRetryServiceResilienceProxy(new RetryWith2FailuresImpl(), retry);
         _zaAllPolicies = new IAllPoliciesServiceResilienceProxy(
             _inner, retry, new TimeoutPolicy(5_000), rl, cb);
@@ -141,5 +143,6 @@ public class PollyComparisonBenchmark
     // package (Polly.RateLimiting) with a different surface; an
     // apples-to-apples all-policies comparison requires a custom
     // interface that pairs each library's policy stack one-for-one.
-    // Deferred to a follow-up.
+    // Tracked in c:/Projects/Prive/ZeroAlloc/docs/COMPARISON-SWEEP-BACKLOG.md
+    // (search "All-policies stacked comparison deferred").
 }


### PR DESCRIPTION
## Summary
Two minor follow-ups from the code review of #35:

1. **Lock in that \`RetryWith2FailuresImpl\` instances must not be shared** between the Polly and ZA pipelines. The class carries an \`Interlocked\` counter; sharing it would cross-pollute the two benchmarks. A future "dedupe this allocation" refactor would silently corrupt the data — the comment now names the trap explicitly.

2. **All-policies removed-row comment now references the sweep backlog** where the follow-up is tracked (\`docs/COMPARISON-SWEEP-BACKLOG.md\`), instead of an unattributed "Deferred" with no destination.

Both items came from the requesting-code-review pass. No code behavior change.

## Test plan
- [x] No measurement change (comment-only)
- [x] Build still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)