### PR TITLE
fix: inject the clock into RateLimiter, making refill tests deterministic

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,10 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.140" PrivateAssets="all">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.141" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0" PrivateAssets="all">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.16.0" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2" PrivateAssets="all">

--- a/src/ZeroAlloc.Resilience/PublicAPI.Unshipped.txt
+++ b/src/ZeroAlloc.Resilience/PublicAPI.Unshipped.txt
@@ -42,6 +42,7 @@ ZeroAlloc.Resilience.RateLimitScope.Instance = 1 -> ZeroAlloc.Resilience.RateLim
 ZeroAlloc.Resilience.RateLimitScope.Shared = 0 -> ZeroAlloc.Resilience.RateLimitScope
 ZeroAlloc.Resilience.RateLimiter
 ZeroAlloc.Resilience.RateLimiter.RateLimiter(int maxPerSecond, int burstSize, ZeroAlloc.Resilience.RateLimitScope scope) -> void
+ZeroAlloc.Resilience.RateLimiter.RateLimiter(int maxPerSecond, int burstSize, ZeroAlloc.Resilience.RateLimitScope scope, System.TimeProvider! timeProvider) -> void
 ZeroAlloc.Resilience.RateLimiter.Scope.get -> ZeroAlloc.Resilience.RateLimitScope
 ZeroAlloc.Resilience.RateLimiter.TryAcquire() -> bool
 ZeroAlloc.Resilience.ResilienceError

--- a/src/ZeroAlloc.Resilience/RateLimiter.cs
+++ b/src/ZeroAlloc.Resilience/RateLimiter.cs
@@ -10,9 +10,10 @@ namespace ZeroAlloc.Resilience;
 public sealed class RateLimiter
 {
     private long _tokens;
-    private long _lastRefillTick;
+    private long _lastRefillTimestamp;
     private readonly int _maxPerSecond;
     private readonly long _burstSize;
+    private readonly TimeProvider _timeProvider;
 
     /// <summary>The configured scope for this limiter.</summary>
     public RateLimitScope Scope { get; }
@@ -21,12 +22,29 @@ public sealed class RateLimiter
     /// <param name="burstSize">Initial and maximum token count.</param>
     /// <param name="scope">Whether this limiter is shared or per-instance.</param>
     public RateLimiter(int maxPerSecond, int burstSize, RateLimitScope scope)
+        : this(maxPerSecond, burstSize, scope, TimeProvider.System)
     {
+    }
+
+    /// <param name="maxPerSecond">Tokens added per second.</param>
+    /// <param name="burstSize">Initial and maximum token count.</param>
+    /// <param name="scope">Whether this limiter is shared or per-instance.</param>
+    /// <param name="timeProvider">
+    /// Clock used to measure refill intervals. Pass a controlled provider to make refill
+    /// behaviour deterministic; the default reads the system clock.
+    /// </param>
+    /// <remarks>
+    /// Refill is measured with <see cref="TimeProvider.GetTimestamp"/> rather than a wall clock,
+    /// so it is monotonic and unaffected by system time changes.
+    /// </remarks>
+    public RateLimiter(int maxPerSecond, int burstSize, RateLimitScope scope, TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         _maxPerSecond = maxPerSecond;
         _burstSize = burstSize;
         Scope = scope;
         _tokens = burstSize;
-        _lastRefillTick = Environment.TickCount64;
+        _lastRefillTimestamp = _timeProvider.GetTimestamp();
     }
 
     /// <summary>Attempts to consume one token. Returns <c>false</c> if the bucket is empty.</summary>
@@ -44,16 +62,19 @@ public sealed class RateLimiter
 
     private void Refill()
     {
-        var now = Environment.TickCount64;
-        var last = Volatile.Read(ref _lastRefillTick);
-        var elapsed = now - last;
-        if (elapsed <= 0) return;
+        var now = _timeProvider.GetTimestamp();
+        var last = Volatile.Read(ref _lastRefillTimestamp);
+        // Timestamps are in TimestampFrequency units, so convert to milliseconds before the
+        // token maths. Leaving _lastRefillTimestamp untouched when this rounds down to zero is
+        // deliberate: sub-millisecond elapsed time accumulates instead of being discarded.
+        var elapsedMs = (now - last) * 1_000L / _timeProvider.TimestampFrequency;
+        if (elapsedMs <= 0) return;
 
-        var toAdd = elapsed * _maxPerSecond / 1_000L;
+        var toAdd = elapsedMs * _maxPerSecond / 1_000L;
         if (toAdd <= 0) return;
 
-        // Only one thread wins the CAS on _lastRefillTick — prevents double-refill
-        if (Interlocked.CompareExchange(ref _lastRefillTick, now, last) != last) return;
+        // Only one thread wins the CAS on _lastRefillTimestamp — prevents double-refill
+        if (Interlocked.CompareExchange(ref _lastRefillTimestamp, now, last) != last) return;
 
         // CAS loop on _tokens so concurrent TryAcquire() consumptions are not overwritten
         long current, next;

--- a/tests/ZeroAlloc.Resilience.Tests/RateLimiterTests.cs
+++ b/tests/ZeroAlloc.Resilience.Tests/RateLimiterTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Time.Testing;
 using System.Threading.Tasks;
 using ZeroAlloc.Resilience;
 
@@ -16,19 +17,33 @@ public class RateLimiterTests
     }
 
     [Fact]
-    public async Task AfterDelay_TokensRefill()
+    public void AfterElapsedTime_TokensRefill()
     {
-        // 10/s, so one token per 100ms. NOT 100/s: that refills every 10ms, which is inside
-        // the granularity of Environment.TickCount64 (~15ms on Windows) that RateLimiter reads.
-        // A single clock tick then refilled a whole token, so the "bucket is now empty"
-        // assertion below raced the clock and failed roughly two runs in five.
-        var limiter = new RateLimiter(maxPerSecond: 10, burstSize: 1, scope: RateLimitScope.Shared);
+        // Deterministic: the limiter reads this clock, so no wall-clock timing is involved.
+        // The previous version ran at 100/s against Environment.TickCount64, whose ~15ms
+        // granularity exceeded the 10ms refill interval -- a single tick handed back a whole
+        // token and the "bucket is empty" assertion failed roughly two runs in five.
+        var time = new FakeTimeProvider();
+        var limiter = new RateLimiter(maxPerSecond: 100, burstSize: 1, RateLimitScope.Shared, time);
 
         limiter.TryAcquire().Should().BeTrue();   // consumes the burst token
-        limiter.TryAcquire().Should().BeFalse();  // empty — has 100ms of slack, not 10ms
+        limiter.TryAcquire().Should().BeFalse();  // empty, and the clock cannot have moved
 
-        await Task.Delay(200); // >= 2 tokens at 10/s, so the wait cannot be marginal either
+        time.Advance(TimeSpan.FromMilliseconds(50)); // exactly 5 tokens at 100/s
         limiter.TryAcquire().Should().BeTrue();
+    }
+
+    [Fact]
+    public void BeforeRefillInterval_StaysEmpty()
+    {
+        // The other half of the contract, which wall-clock timing could never assert:
+        // just under one token's worth of time must refill nothing.
+        var time = new FakeTimeProvider();
+        var limiter = new RateLimiter(maxPerSecond: 100, burstSize: 1, RateLimitScope.Shared, time);
+
+        limiter.TryAcquire().Should().BeTrue();
+        time.Advance(TimeSpan.FromMilliseconds(9)); // one token needs 10ms
+        limiter.TryAcquire().Should().BeFalse();
     }
 
     [Fact]

--- a/tests/ZeroAlloc.Resilience.Tests/RateLimiterTests.cs
+++ b/tests/ZeroAlloc.Resilience.Tests/RateLimiterTests.cs
@@ -18,11 +18,16 @@ public class RateLimiterTests
     [Fact]
     public async Task AfterDelay_TokensRefill()
     {
-        var limiter = new RateLimiter(maxPerSecond: 100, burstSize: 1, scope: RateLimitScope.Shared);
-        limiter.TryAcquire().Should().BeTrue();
-        limiter.TryAcquire().Should().BeFalse();
+        // 10/s, so one token per 100ms. NOT 100/s: that refills every 10ms, which is inside
+        // the granularity of Environment.TickCount64 (~15ms on Windows) that RateLimiter reads.
+        // A single clock tick then refilled a whole token, so the "bucket is now empty"
+        // assertion below raced the clock and failed roughly two runs in five.
+        var limiter = new RateLimiter(maxPerSecond: 10, burstSize: 1, scope: RateLimitScope.Shared);
 
-        await Task.Delay(50); // ~5 tokens at 100/s
+        limiter.TryAcquire().Should().BeTrue();   // consumes the burst token
+        limiter.TryAcquire().Should().BeFalse();  // empty — has 100ms of slack, not 10ms
+
+        await Task.Delay(200); // >= 2 tokens at 10/s, so the wait cannot be marginal either
         limiter.TryAcquire().Should().BeTrue();
     }
 

--- a/tests/ZeroAlloc.Resilience.Tests/ZeroAlloc.Resilience.Tests.csproj
+++ b/tests/ZeroAlloc.Resilience.Tests/ZeroAlloc.Resilience.Tests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
     <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <ProjectReference Include="..\..\src\ZeroAlloc.Resilience\ZeroAlloc.Resilience.csproj" />
     <ProjectReference Include="..\..\..\ZeroAlloc.Results\src\ZeroAlloc.Results\ZeroAlloc.Results.csproj" />


### PR DESCRIPTION
Supersedes **#60**, the grouped analyzer bump, which failed on a **flaky test** rather than on anything the analyzers reported.

## Why the test was broken, not unlucky

```
Expected limiter.TryAcquire() to be False, but found True.
```

Reproduced locally at **2 failures in 5 runs**. It also failed **Resilience#55** earlier this week, which is what made me look instead of re-running.

The failing assertion was the **second** `TryAcquire`, not the one after the delay. At `maxPerSecond: 100` a token refills every **10 ms**, and `RateLimiter` measured elapsed time with `Environment.TickCount64`, whose granularity is around **15 ms** on Windows.

**The refill interval was smaller than the clock used to measure it.** A single tick landing between two adjacent statements handed back a whole token, so "the bucket is now empty" was legitimately wrong.

## The fix: inject the clock

`RateLimiter` now takes a `TimeProvider`:

```csharp
public RateLimiter(int maxPerSecond, int burstSize, RateLimitScope scope)
    : this(maxPerSecond, burstSize, scope, TimeProvider.System) { }

public RateLimiter(int maxPerSecond, int burstSize, RateLimitScope scope, TimeProvider timeProvider)
```

- **Nothing changes for existing callers** — the three-argument constructor delegates with `TimeProvider.System`. The addition is recorded in `PublicAPI.Unshipped.txt`.
- `Refill` moves from `Environment.TickCount64` to `TimeProvider.GetTimestamp()`, converting through `TimestampFrequency` so the **token maths is unchanged**. `GetTimestamp` is monotonic, so refill is also immune to system time changes.
- `ZeroAlloc.Resilience` targets `net8.0;net9.0;net10.0` — no `netstandard2.0` — so `TimeProvider` is available on every target with **no polyfill package**.

An earlier commit on this branch only widened the timing margins. That hid the race rather than removing it, and is replaced here.

## What determinism buys beyond stability

The test now asserts the contract instead of racing it — and a second test becomes possible that wall-clock timing could never express:

```csharp
time.Advance(TimeSpan.FromMilliseconds(9)); // one token needs 10ms
limiter.TryAcquire().Should().BeFalse();    // just under the interval refills nothing
```

The old test could only ever check that *enough* time refills a token. It could never check that *not quite enough* refills none.

## Verification

- **15 consecutive runs pass**, where the old test failed **2 in 5**
- Full suite green — **27 runtime tests** (one more than before), **8 generator tests**
- Build **0 errors**; warnings **unchanged at 42, no new diagnostic codes** — measured on *clean* builds both with and without this change, since they come from the analyzer bump this PR supersedes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
